### PR TITLE
Avoid removing white spaces from paragraph in SQuAD

### DIFF
--- a/chazutsu/datasets/squad.py
+++ b/chazutsu/datasets/squad.py
@@ -80,7 +80,7 @@ class SQuAD(Dataset):
 
         for article in xtqdm(data):
             for paragraph in article["paragraphs"]:
-                context = paragraph["context"].strip().replace("\n", "")
+                context = paragraph["context"].replace("\n", " ")
                 for qa in paragraph["qas"]:
                     question = qa["question"].strip().replace("\n", "")
                     row = make_row(context, question, qa)


### PR DESCRIPTION
- Avoid removing white spaces from paragraph otherwise the answer will be changed
    - Avoid using `strip` method
    - Replace `\n` to `(space)` in paragraph 
- Check test cases passed